### PR TITLE
Ensure that usernames and passwords are escaped when used in commands

### DIFF
--- a/checks/ipv4/ftp/download.rb
+++ b/checks/ipv4/ftp/download.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -15,8 +16,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/ftp/upload.rb
+++ b/checks/ipv4/ftp/upload.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -22,8 +23,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/ftps/download.rb
+++ b/checks/ipv4/ftps/download.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -20,8 +21,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/ftps/upload.rb
+++ b/checks/ipv4/ftps/upload.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -22,8 +23,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/mysql/login.rb
+++ b/checks/ipv4/mysql/login.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -12,8 +13,8 @@ module ScoringEngine
       def command_str
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         database = get_random_property("database")
         raise "Missing database" unless database

--- a/checks/ipv4/pop3/login.rb
+++ b/checks/ipv4/pop3/login.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -19,8 +20,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # URL
         cmd << " pop3://#{username}:#{password}@#{ip} "

--- a/checks/ipv4/pop3s/login.rb
+++ b/checks/ipv4/pop3s/login.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -19,8 +20,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # URL
         cmd << " pop3://#{username}:#{password}@#{ip} "

--- a/checks/ipv4/smb/download.rb
+++ b/checks/ipv4/smb/download.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -20,14 +21,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
-
-        # User
-        user = service.users.sample
-        raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = user.username.shellwords
+        password = user.password.shellwords
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/smb/download.rb
+++ b/checks/ipv4/smb/download.rb
@@ -21,8 +21,8 @@ module ScoringEngine
         # User
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username.shellwords
-        password = user.password.shellwords
+        username = user.username.shellescape
+        password = user.password.shellescape
 
         # Default filename
         filename = get_random_property('filename')

--- a/checks/ipv4/smtp/send-mail.rb
+++ b/checks/ipv4/smtp/send-mail.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -23,15 +24,15 @@ module ScoringEngine
         from_user = service.users.sample unless from_user
 
         raise "Missing users" unless from_user
-        from_username = from_user.username
-        from_password = from_user.password
+        from_username = from_user.username.shellescape
+        from_password = from_user.password.shellescape
 
         # From Domain
         from_domain = service.properties.option('from-domain')
         raise("Missing from-domain property") unless from_domain
 
         # Add From Email
-        cmd << " --mail-from '#{from_username}'@'#{from_domain}' "
+        cmd << " --mail-from #{from_username}@'#{from_domain}' "
 
         # Rcpt User
         rcpt_user = get_random_property('rcpt-user')

--- a/checks/ipv4/smtps/send-mail.rb
+++ b/checks/ipv4/smtps/send-mail.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -23,15 +24,15 @@ module ScoringEngine
         from_user = service.users.sample unless from_user
 
         raise "Missing users" unless from_user
-        from_username = from_user.username
-        from_password = from_user.password
+        from_username = from_user.username.shellescape
+        from_password = from_user.password.shellescape
 
         # From Domain
         from_domain = service.properties.option('from-domain')
         raise("Missing from-domain property") unless from_domain
 
         # Add From Email
-        cmd << " --mail-from '#{from_username}'@'#{from_domain}' "
+        cmd << " --mail-from #{from_username}@'#{from_domain}' "
 
         # Rcpt User
         rcpt_user = get_random_property('rcpt-user')

--- a/checks/ipv4/ssh/login.rb
+++ b/checks/ipv4/ssh/login.rb
@@ -1,4 +1,5 @@
 require 'scoring_engine'
+require 'shellwords'
 
 module ScoringEngine
   module Checks
@@ -9,16 +10,20 @@ module ScoringEngine
       PROTOCOL = "ssh"
       VERSION = "ipv4"
 
+      def escape(str)
+        return str.gsub('}','\\}').gsub('{', '\\{').shellescape
+      end
+
       def command_str
         user = service.users.sample
         raise "Missing users" unless user
-        username = user.username
-        password = user.password
+        username = escape(user.username)
+        password = escape(user.password)
 
         command = get_random_property("command")
         raise "Missing command" unless command
 
-        cmd = "expect -c 'spawn ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no #{username}@#{ip} #{command}; expect \"assword\"; send \"#{password}\r\"; interact'"
+        cmd = "expect -c 'spawn ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {'#{username}'@#{ip}} #{command}; expect \"assword\"; send {'#{password}'\r}; interact'"
 
         return cmd
       end

--- a/rakelib/whiteteam.rake
+++ b/rakelib/whiteteam.rake
@@ -102,6 +102,7 @@ namespace :scoringengine do
     # MySQL Login
     service = Service.create(team_id: team.id, server_id: server.id, name: "MySQL Login", version: 'ipv4', protocol: 'mysql', enabled: false, available_points: 0)
     property = Property.create(team_id: team.id, server_id: server.id, service_id: service.id, visible: true, category: 'random', property: 'command', value: 'show tables')
+    property = Property.create(team_id: team.id, server_id: server.id, service_id: service.id, visible: true, category: 'random', property: 'database', value: 'testdb')
     property = Property.create(team_id: team.id, server_id: server.id, service_id: service.id, visible: true, category: 'answer', property: 'each-line-regex', value: 'Tables_in_')
 
     # NFS Available
@@ -111,7 +112,7 @@ namespace :scoringengine do
     service = Service.create(team_id: team.id, server_id: server.id, name: "NFS Content", version: 'ipv4', protocol: 'nfs', enabled: false, available_points: 0)
 
     # NFS Download
-    service = Service.create(team_id: team.id, server_id: server.id, name: "NFS Download", version: 'ipv4', protocol: 'nfs', enabled: true, available_points: 0)
+    service = Service.create(team_id: team.id, server_id: server.id, name: "NFS Download", version: 'ipv4', protocol: 'nfs', enabled: false, available_points: 0)
     property = Property.create(team_id: team.id, server_id: server.id, service_id: service.id, visible: true, category: 'option', property: 'share', value: '/var/opt')
     property = Property.create(team_id: team.id, server_id: server.id, service_id: service.id, visible: true, category: 'option', property: 'filename', value: 'testfile.txt')
 


### PR DESCRIPTION
All fields in the User object, which is controlled by the blue team, are now shell escaped. In some cases, such as the SSH login expect script, additional escaping was required.
